### PR TITLE
Fix helm install command for ArgoCD

### DIFF
--- a/Question-2-ArgoCD/SolutionNotes.bash
+++ b/Question-2-ArgoCD/SolutionNotes.bash
@@ -7,8 +7,8 @@ helm repo update
 
 # To get the crd value to change, you can run: helm show values argocd/argo-cd --version 7.7.3 | grep -i crd -C 4
 
-helm install argocd argo/argo-cd --version 7.7.3 --set crds.install=false --namespace argocd
-helm template argocd argo/argo-cd --version 7.7.3 --set crds.install=false --namespace argocd > /root/argo-helm.yaml
+helm install argocd argocd/argo-cd --version 7.7.3 --set crds.install=false --namespace argocd
+helm template argocd argocd/argo-cd --version 7.7.3 --set crds.install=false --namespace argocd > /root/argo-helm.yaml
 cat /root/argo-helm.yaml   # confirm output
 
 


### PR DESCRIPTION
it was failing as it was installin `argo/argo-cd` instead of `argocd/argo-cd`