### PR TITLE
Question8 manifest repo change

### DIFF
--- a/Question-8-CNI-Network-Policy/Questions.bash
+++ b/Question-8-CNI-Network-Policy/Questions.bash
@@ -8,7 +8,7 @@
 # or
 
 # Calico (v3.28.2) using the manifest tigera-operator.yaml
-# (https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/tigera-operator.yaml)
+# (https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/calico.yaml)
 
 # The CNI you choose must
 # 1. Let pods communicate with each other

--- a/Question-8-CNI-Network-Policy/cleanup.bash
+++ b/Question-8-CNI-Network-Policy/cleanup.bash
@@ -4,7 +4,7 @@ set -uo pipefail
 echo "Cleaning up Question 8: CNI & Network Policy..."
 
 # Remove Calico/tigera-operator if installed
-kubectl delete -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/tigera-operator.yaml 2>/dev/null || true
+kubectl delete -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/calico.yaml 2>/dev/null || true
 kubectl delete namespace tigera-operator --ignore-not-found
 kubectl delete namespace calico-system --ignore-not-found
 


### PR DESCRIPTION
as described in issue #39. The repo was only applying the tigera operator which does not configure cluster networking. The required Calico Installation custom resource is not created, so the CNI components are never fully initialized on the nodes. Nodes stay not ready. 

Changed the question and the cleanup.